### PR TITLE
Support the updates to the Android SDK 3.0.7

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -25,6 +25,8 @@ import android.util.Log;
 
 import com.google.android.gms.gcm.GcmListenerService;
 
+import io.intercom.android.sdk.push.IntercomPushClient;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -40,6 +42,7 @@ import java.util.Random;
 
 @SuppressLint("NewApi")
 public class GCMIntentService extends GcmListenerService implements PushConstants {
+    private static final IntercomPushClient intercomPushClient = new IntercomPushClient();
 
     private static final String LOG_TAG = "PushPlugin_GCMIntentService";
     private static HashMap<Integer, ArrayList<String>> messageMap = new HashMap<Integer, ArrayList<String>>();
@@ -62,8 +65,13 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
     public void onMessageReceived(String from, Bundle extras) {
         Log.d(LOG_TAG, "onMessage - from: " + from);
 
-        if (extras != null  && !PushPlugin.isIntercomPush(extras)) {
 
+        if (extras == null) {
+            return;
+        }
+        if (intercomPushClient.isIntercomPush(extras)) {
+            intercomPushClient.handlePush(getApplication(), extras);
+        } else {
             SharedPreferences prefs = getApplicationContext().getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);
             boolean forceShow = prefs.getBoolean(FORCE_SHOW, false);
             boolean clearBadge = prefs.getBoolean(CLEAR_BADGE, false);

--- a/src/android/com/adobe/phonegap/push/RegistrationIntentService.java
+++ b/src/android/com/adobe/phonegap/push/RegistrationIntentService.java
@@ -10,9 +10,12 @@ import android.util.Log;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.google.android.gms.iid.InstanceID;
 
+import io.intercom.android.sdk.push.IntercomPushClient;
+
 import java.io.IOException;
 
 public class RegistrationIntentService extends IntentService implements PushConstants {
+    private static final IntercomPushClient intercomPushClient = new IntercomPushClient();
     public static final String LOG_TAG = "PushPlugin_RegistrationIntentService";
 
     public RegistrationIntentService() {
@@ -30,6 +33,7 @@ public class RegistrationIntentService extends IntentService implements PushCons
                     GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
             Log.i(LOG_TAG, "new GCM Registration Token: " + token);
 
+            intercomPushClient.sendTokenToIntercom(getApplication(), token);
             // save new token
             SharedPreferences.Editor editor = sharedPreferences.edit();
             editor.putString(REGISTRATION_ID, token);


### PR DESCRIPTION
This allows the push plugin to forward on registration and creation of push messages to Intercom while still supporting the host apps push.
