### PR TITLE
Allow more recent versions of Google Play services GCM library

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
     </config-file>
     <framework src="push.gradle" custom="true" type="gradleReference"/>
     <framework src="com.android.support:support-v13:23+"/>
-    <framework src="com.google.android.gms:play-services-gcm:9.0.2+"/>
+    <framework src="com.google.android.gms:play-services-gcm:9.+"/>
     <framework src="me.leolin:ShortcutBadger:1.1.4@aar"/>
     <source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/"/>


### PR DESCRIPTION
This change updates the plugin.xml to allow newer versions of the com.google.android.gms:play-services-gcm to be included. This ensures that newer versions of other Google Play services libraries that may be included in the same application by other cordova plugins will be compatible.

This change addresses an issue with the latest version of the Google Play services library where the application crashes on access to IntentService.
