### PR TITLE
Update readme to show the fork as obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This fork is obsolete
+
+As of [3.1.2](https://github.com/intercom/intercom-cordova/releases/tag/3.1.2) of the Intercom Cordova plugin, this fork is no longer needed for compatibility with `phonegap-plugin-push`. Please use the [offical phonegap-plugin-push](phonegap/phonegap-plugin-push).
+
 #phonegap-plugin-push [![Build Status](https://travis-ci.org/phonegap/phonegap-plugin-push.svg)](https://travis-ci.org/phonegap/phonegap-plugin-push)
 
 > Register and receive push notifications


### PR DESCRIPTION
As of [3.1.2](https://github.com/intercom/intercom-cordova/releases/tag/3.1.2) of the Intercom Cordova plugin, this fork is no longer needed for compatibility with `phonegap-plugin-push`.