### PR TITLE
Send tokens and Intercom push payloads to Intercom SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Intercom Fork
+
+This plugin is a forked version of [phonegap/phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push) which allows compatibility with the Intercom SDK.
+
 # phonegap-plugin-push [![Build Status](https://travis-ci.org/phonegap/phonegap-plugin-push.svg)](https://travis-ci.org/phonegap/phonegap-plugin-push)
 
 > Register and receive push notifications

--- a/plugin.xml
+++ b/plugin.xml
@@ -38,11 +38,10 @@
         </intent-filter>
       </service>
     </config-file>
-    <framework src="com.android.support:support-v13:26.+"/>
+    <framework src="com.android.support:support-v13:27.+"/>
     <framework src="me.leolin:ShortcutBadger:1.1.17@aar"/>
-    <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION"/>
+    <framework src="com.google.firebase:firebase-messaging:11.+"/>
     <framework src="push.gradle" custom="true" type="gradleReference"/>
-    <preference name="FCM_VERSION" default="11.6.2"/>
     <source-file src="src/android/com/adobe/phonegap/push/FCMService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushHandlerActivity.java" target-dir="src/com/adobe/phonegap/push/"/>

--- a/push.gradle
+++ b/push.gradle
@@ -25,7 +25,7 @@ buildscript {
   }
   dependencies {
       classpath 'com.android.tools.build:gradle:+'
-      classpath 'com.google.gms:google-services:3.0.0'
+      classpath 'com.google.gms:google-services:3.2.0'
   }
 }
 

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -33,6 +33,8 @@ import android.util.Log;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import io.intercom.android.sdk.push.IntercomPushClient;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -54,6 +56,8 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
   private static final String LOG_TAG = "Push_FCMService";
   private static HashMap<Integer, ArrayList<String>> messageMap = new HashMap<Integer, ArrayList<String>>();
 
+  private final IntercomPushClient intercomPushClient = new IntercomPushClient();
+
   public void setNotification(int notId, String message) {
     ArrayList<String> messageList = messageMap.get(notId);
     if (messageList == null) {
@@ -70,6 +74,11 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
   @Override
   public void onMessageReceived(RemoteMessage message) {
+
+    if (intercomPushClient.isIntercomPush(message.getData())) {
+        intercomPushClient.handlePush(getApplication(), message.getData());
+        return;
+    }
 
     String from = message.getFrom();
     Log.d(LOG_TAG, "onMessage - from: " + from);

--- a/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
+++ b/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
@@ -8,6 +8,8 @@ import android.util.Log;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.FirebaseInstanceIdService;
 
+import io.intercom.android.sdk.push.IntercomPushClient;
+
 import org.json.JSONException;
 
 import java.io.IOException;
@@ -15,12 +17,12 @@ import java.io.IOException;
 public class PushInstanceIDListenerService extends FirebaseInstanceIdService implements PushConstants {
     public static final String LOG_TAG = "Push_InsIdService";
 
+    private final IntercomPushClient intercomPushClient = new IntercomPushClient();
+
     @Override
     public void onTokenRefresh() {
         // Get updated InstanceID token.
         String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-        Log.d(LOG_TAG, "Refreshed token: " + refreshedToken);
-        // TODO: Implement this method to send any registration to your app's servers.
-        //sendRegistrationToServer(refreshedToken);
+        intercomPushClient.sendTokenToIntercom(getApplication(), refreshedToken);
     }
 }


### PR DESCRIPTION
Allows Intercom notifications to work when this fork of the plugin is used.